### PR TITLE
[#76] removes iTerm from the list of available terminals.

### DIFF
--- a/Shared/Terminal.swift
+++ b/Shared/Terminal.swift
@@ -50,7 +50,7 @@ class TerminalApplications {
     private var terminalsDictionary = [String: ErlangTerminal]()
 
     init() {
-        let allTerminals: [ErlangTerminal] = [iTerm(), Terminal()]
+        let allTerminals: [ErlangTerminal] = [Terminal()]
         for terminal in allTerminals {
             if terminal.installed {
                 terminalsDictionary[terminal.applicationName] = terminal


### PR DESCRIPTION
Only OS X's Terminal.app is supported for now.
