### PR TITLE
Fix preferences window not showing up.

### DIFF
--- a/ErlangInstaller/MainMenu.swift
+++ b/ErlangInstaller/MainMenu.swift
@@ -20,7 +20,7 @@ class MainMenu: NSMenu, NSUserNotificationCenterDelegate, PopoverDelegate {
 	private var statusItem : NSStatusItem?
     private var timer : NSTimer?
     
-    let preferencesWindow = ErlangInstallerPreferences.sharedInstance
+    var preferencesWindow: ErlangInstallerPreferences?
 	
     @IBOutlet weak var erlangTerminalDefault: NSMenuItem!
     @IBOutlet weak var erlangTerminals: NSMenuItem!
@@ -30,23 +30,21 @@ class MainMenu: NSMenu, NSUserNotificationCenterDelegate, PopoverDelegate {
     }
 	
     @IBAction func showPreferencesPane(sender: AnyObject) {
-        self.preferencesWindow.showWindow(self)
-        
-        if let tabView = self.preferencesWindow.tabView {
-			tabView.selectTabViewItemWithIdentifier("erlang")
-		}
-		
+        self.showNewPreferencesPane(selectingTabWithIdentifier: "erlang")
 	}
 	
 	func showPreferencesPaneAndOpenReleasesTab(sender: AnyObject) {
-		let preferencesWindow =  ErlangInstallerPreferences.sharedInstance
-		preferencesWindow.showWindow(self)
-		
-		if let tabView = preferencesWindow.tabView {
-			tabView.selectTabViewItemWithIdentifier("releases")
-		}
+		self.showNewPreferencesPane(selectingTabWithIdentifier: "releases")
 	}
 	
+    func showNewPreferencesPane(selectingTabWithIdentifier identifier: String? = nil) {
+        self.preferencesWindow = ErlangInstallerPreferences()
+        self.preferencesWindow!.showWindow(self)
+        if let tabView = self.preferencesWindow!.tabView, let itemIdentifier = identifier {
+            tabView.selectTabViewItemWithIdentifier(itemIdentifier)
+        }
+    }
+    
 	func showPopover(sender: AnyObject?) {
 		if let button = statusItem!.button {
 			popover.showRelativeToRect(button.bounds, ofView: button, preferredEdge: NSRectEdge.MinY)

--- a/ErlangInstallerPreferences/ErlangInstallerPreferences.swift
+++ b/ErlangInstallerPreferences/ErlangInstallerPreferences.swift
@@ -12,7 +12,6 @@ import ScriptingBridge
 import ServiceManagement
 
 class ErlangInstallerPreferences: NSWindowController, refreshPreferences{
-	static internal let sharedInstance = ErlangInstallerPreferences()
 
 	private var erlangInstallerApp: ErlangInstallerApplication?
 	


### PR DESCRIPTION
- The window instance needs to be kept in the class scope, otherwise it gets released when going out of the function scope, because of ARC. Once again, thanks [stack overflow](http://stackoverflow.com/questions/15853901/loading-nib-file-using-nswindowcontroller-work-but-window-not-visible), hehe.

- ⛔️ @sebacancinos check out that currently, the app is crashing (EXC_BAD_ACCESS) when you close the preferences pane. I bet you will manage to fix that in your branch.